### PR TITLE
Don't filter out TF2 '.pop' files in the VPK dump file extension filter

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -45,7 +45,7 @@ ProcessVPK ()
 		
 		../.support/vpktool "$file" > "${file%.*}.txt"
 		
-		dotnet /home/steamdb/ValveResourceFormat/Decompiler/bin/Release/netcoreapp2.0/Decompiler.dll --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vpcf_c,txt,cfg,res,png,jpg,gif"
+		dotnet /home/steamdb/ValveResourceFormat/Decompiler/bin/Release/netcoreapp2.0/Decompiler.dll --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vpcf_c,txt,cfg,res,pop,png,jpg,gif"
 	done <   <(find . -type f -name "*_dir.vpk" -print0)
 }
 


### PR DESCRIPTION
Yesterday, @FlaminSarge mentioned to me that the GameTracking-TF2 repo doesn't dump TF2's MvM pop files (in `tf2_misc_dir.vpk`: `scripts/population/*.pop`). And sure enough, [they aren't there](https://github.com/SteamDatabase/GameTracking-TF2/tree/master/tf/tf2_misc_dir/scripts).

Now I didn't do an exhaustive check on this, but I'm reasonably sure that the culprit is the `--vpk_extensions` filter, which doesn't include `pop`. This PR adds it; which, to my understanding, should cause TF2's MvM pop files to be dumped in GameTracking-TF2 (and then subsequently tracked for changes).

----

On a somewhat unrelated topic, I had an idea/suggestion that I think would make SteamDB's GameTracking facility even more useful for its users.

It should be fairly easy to integrate some code into the scripts here that (a) ensures that `.ctx` files are extracted from VPK's; and then (b) automatically runs `vice` on them to decrypt all `.ctx` files into plaintext `.txt` files. (Using the appropriate ICE key for the game being processed, of course.) This way, whenever Valve makes changes to files like e.g. `tf/scripts/playerclasses/*.ctx` or `tf/scripts/tf_weapon_*.ctx` (fundamental playerclass and weapon scripts), those changes would now be easily visible to users in the GameTracking diffs.

In particular here, I'm thinking of cases like the July 7, 2016 Meet Your Match update to TF2, where Valve changed the spy class's base move speed from 300 to 320 (this was done via a change to the `"speed_max"` value in `tf/scripts/playerclasses/spy.ctx`); or the October 20, 2017 Jungle Inferno update to TF2, where Valve added new weapons such as the Dragon's Fury, Thermal Thruster, Gas Passer, and Hot Hand, which each came along with their own new weapon script files (`tf/scripts/tf_weapon_rocketlauncher_fireball.ctx`, `tf_weapon_rocketpack.ctx`, `tf_weapon_jar_gas.txt, and `tf_weapon_slap.ctx`, respectively); or other updates in which Valve has made adjustments to the game's weapons by altering their base weapon script files rather than tweaking their item schema entries.

I would code up a prototype of this myself, but the way the scripts and programs interoperate here is a bit complex and cross-repo and just generally makes me unsure that I wouldn't screw something up badly. (Plus I wouldn't trust myself to definitely implement it in a way that would fit in with the way you guys want everything to ideally work, and fit in correctly with the automatic scripts, and all that. Somewhat hard to test from my end, as well.)

Here are some resources that might come in handy:
https://developer.valvesoftware.com/wiki/ICE
https://github.com/foobarhl/vice_standalone/

And let me know what you think of the idea!