### PR TITLE
Include files with .gameevents extension

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -45,7 +45,7 @@ ProcessVPK ()
 		
 		"$(dirname "${BASH_SOURCE[0]}")/.support/vpktool" "$file" > "${file%.*}.txt"
 		
-		dotnet /home/steamdb/ValveResourceFormat/Decompiler/bin/Release/netcoreapp2.0/Decompiler.dll --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vpcf_c,json,txt,cfg,res,pop,png,jpg,gif"
+		dotnet /home/steamdb/ValveResourceFormat/Decompiler/bin/Release/netcoreapp2.0/Decompiler.dll --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vpcf_c,json,txt,cfg,res,pop,gameevents,png,jpg,gif"
 	done <   <(find . -type f -name "*_dir.vpk" -print0)
 }
 

--- a/files.json
+++ b/files.json
@@ -17,7 +17,7 @@
 	],
 	"373301":
 	[
-		"regex:.+?\\.(vpk|vdf|kv3|txt|cfg|lst|db|jpg|png|gif|inf|gi|fgd|lua|json|vcfg)",
+		"regex:.+?\\.(vpk|vdf|kv3|txt|cfg|lst|db|jpg|png|gif|inf|gi|fgd|lua|json|vcfg|gameevents)",
 	],
 	"381450":
 	[


### PR DESCRIPTION
`.gameevents` is a new extension for files that replaced `resource/*events.res`. Now it's used in Dota Underlords, Dota 2, and some Valve's custom games (looks like all of them are in the depot 373301).