### PR TITLE
Add scr and rc files to VPK decompile

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -52,7 +52,7 @@ ProcessVPK ()
 		# https://github.com/Penguinwizzard/VPKTool
 		"$(dirname "${BASH_SOURCE[0]}")/.support/vpktool" "$file" > "${file%.*}.txt"
 		
-		~/ValveResourceFormat/Decompiler/bin/Release/linux-x64/publish/Decompiler --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vsndstck_c,vdpn_c,json,txt,cfg,res,pop,gameevents,png,jpg,gif,ctx"
+		~/ValveResourceFormat/Decompiler/bin/Release/linux-x64/publish/Decompiler --input "$file" --output "$(echo "$file" | sed -e 's/\.vpk$/\//g')" --vpk_cache --vpk_decompile --vpk_extensions "vxml_c,vjs_c,vcss_c,vsndevts_c,vsndstck_c,vdpn_c,json,txt,cfg,scr,res,pop,gameevents,png,jpg,gif,ctx"
 	done <   <(find . -type f -name "*_dir.vpk" -print0)
 }
 


### PR DESCRIPTION
`scr` files are used for specifying default settings layout for various menus in TF2 (in `cfg/user_default.scr` and `cfg/settings_default.scr`)

`user_default.scr` was most recently changed in the October 1 2020 (https://www.teamfortress.com/post.php?id=76112) and June 16 2020 (https://www.teamfortress.com/post.php?id=62459) updates, so there is some value in tracking new changes to these UI elements.

`valve.rc` is a config file which is executed by the game for basic config setup. this file is used commonly by HUDs to script the game before user configs, so it's useful to have available loosely.